### PR TITLE
Update to latest koza API

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
       #    install your root project, if required
       #----------------------------------------------
       - name: Install library
-        run: poetry install --no-interaction
+        run: make install
 
       #----------------------------------------------
       #              run pytest

--- a/poetry.lock
+++ b/poetry.lock
@@ -440,6 +440,106 @@ files = [
 test = ["dict_hash", "pytest", "pytest-readme", "random_dict", "validate_version_code"]
 
 [[package]]
+name = "coverage"
+version = "7.10.5"
+description = "Code coverage measurement for Python"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "coverage-7.10.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c6a5c3414bfc7451b879141ce772c546985163cf553f08e0f135f0699a911801"},
+    {file = "coverage-7.10.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:bc8e4d99ce82f1710cc3c125adc30fd1487d3cf6c2cd4994d78d68a47b16989a"},
+    {file = "coverage-7.10.5-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:02252dc1216e512a9311f596b3169fad54abcb13827a8d76d5630c798a50a754"},
+    {file = "coverage-7.10.5-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:73269df37883e02d460bee0cc16be90509faea1e3bd105d77360b512d5bb9c33"},
+    {file = "coverage-7.10.5-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f8a81b0614642f91c9effd53eec284f965577591f51f547a1cbeb32035b4c2f"},
+    {file = "coverage-7.10.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:6a29f8e0adb7f8c2b95fa2d4566a1d6e6722e0a637634c6563cb1ab844427dd9"},
+    {file = "coverage-7.10.5-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:fcf6ab569436b4a647d4e91accba12509ad9f2554bc93d3aee23cc596e7f99c3"},
+    {file = "coverage-7.10.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:90dc3d6fb222b194a5de60af8d190bedeeddcbc7add317e4a3cd333ee6b7c879"},
+    {file = "coverage-7.10.5-cp310-cp310-win32.whl", hash = "sha256:414a568cd545f9dc75f0686a0049393de8098414b58ea071e03395505b73d7a8"},
+    {file = "coverage-7.10.5-cp310-cp310-win_amd64.whl", hash = "sha256:e551f9d03347196271935fd3c0c165f0e8c049220280c1120de0084d65e9c7ff"},
+    {file = "coverage-7.10.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c177e6ffe2ebc7c410785307758ee21258aa8e8092b44d09a2da767834f075f2"},
+    {file = "coverage-7.10.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:14d6071c51ad0f703d6440827eaa46386169b5fdced42631d5a5ac419616046f"},
+    {file = "coverage-7.10.5-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:61f78c7c3bc272a410c5ae3fde7792b4ffb4acc03d35a7df73ca8978826bb7ab"},
+    {file = "coverage-7.10.5-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f39071caa126f69d63f99b324fb08c7b1da2ec28cbb1fe7b5b1799926492f65c"},
+    {file = "coverage-7.10.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:343a023193f04d46edc46b2616cdbee68c94dd10208ecd3adc56fcc54ef2baa1"},
+    {file = "coverage-7.10.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:585ffe93ae5894d1ebdee69fc0b0d4b7c75d8007983692fb300ac98eed146f78"},
+    {file = "coverage-7.10.5-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:b0ef4e66f006ed181df29b59921bd8fc7ed7cd6a9289295cd8b2824b49b570df"},
+    {file = "coverage-7.10.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:eb7b0bbf7cc1d0453b843eca7b5fa017874735bef9bfdfa4121373d2cc885ed6"},
+    {file = "coverage-7.10.5-cp311-cp311-win32.whl", hash = "sha256:1d043a8a06987cc0c98516e57c4d3fc2c1591364831e9deb59c9e1b4937e8caf"},
+    {file = "coverage-7.10.5-cp311-cp311-win_amd64.whl", hash = "sha256:fefafcca09c3ac56372ef64a40f5fe17c5592fab906e0fdffd09543f3012ba50"},
+    {file = "coverage-7.10.5-cp311-cp311-win_arm64.whl", hash = "sha256:7e78b767da8b5fc5b2faa69bb001edafcd6f3995b42a331c53ef9572c55ceb82"},
+    {file = "coverage-7.10.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c2d05c7e73c60a4cecc7d9b60dbfd603b4ebc0adafaef371445b47d0f805c8a9"},
+    {file = "coverage-7.10.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:32ddaa3b2c509778ed5373b177eb2bf5662405493baeff52278a0b4f9415188b"},
+    {file = "coverage-7.10.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:dd382410039fe062097aa0292ab6335a3f1e7af7bba2ef8d27dcda484918f20c"},
+    {file = "coverage-7.10.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7fa22800f3908df31cea6fb230f20ac49e343515d968cc3a42b30d5c3ebf9b5a"},
+    {file = "coverage-7.10.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f366a57ac81f5e12797136552f5b7502fa053c861a009b91b80ed51f2ce651c6"},
+    {file = "coverage-7.10.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5f1dc8f1980a272ad4a6c84cba7981792344dad33bf5869361576b7aef42733a"},
+    {file = "coverage-7.10.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:2285c04ee8676f7938b02b4936d9b9b672064daab3187c20f73a55f3d70e6b4a"},
+    {file = "coverage-7.10.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c2492e4dd9daab63f5f56286f8a04c51323d237631eb98505d87e4c4ff19ec34"},
+    {file = "coverage-7.10.5-cp312-cp312-win32.whl", hash = "sha256:38a9109c4ee8135d5df5505384fc2f20287a47ccbe0b3f04c53c9a1989c2bbaf"},
+    {file = "coverage-7.10.5-cp312-cp312-win_amd64.whl", hash = "sha256:6b87f1ad60b30bc3c43c66afa7db6b22a3109902e28c5094957626a0143a001f"},
+    {file = "coverage-7.10.5-cp312-cp312-win_arm64.whl", hash = "sha256:672a6c1da5aea6c629819a0e1461e89d244f78d7b60c424ecf4f1f2556c041d8"},
+    {file = "coverage-7.10.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ef3b83594d933020f54cf65ea1f4405d1f4e41a009c46df629dd964fcb6e907c"},
+    {file = "coverage-7.10.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2b96bfdf7c0ea9faebce088a3ecb2382819da4fbc05c7b80040dbc428df6af44"},
+    {file = "coverage-7.10.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:63df1fdaffa42d914d5c4d293e838937638bf75c794cf20bee12978fc8c4e3bc"},
+    {file = "coverage-7.10.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8002dc6a049aac0e81ecec97abfb08c01ef0c1fbf962d0c98da3950ace89b869"},
+    {file = "coverage-7.10.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:63d4bb2966d6f5f705a6b0c6784c8969c468dbc4bcf9d9ded8bff1c7e092451f"},
+    {file = "coverage-7.10.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1f672efc0731a6846b157389b6e6d5d5e9e59d1d1a23a5c66a99fd58339914d5"},
+    {file = "coverage-7.10.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:3f39cef43d08049e8afc1fde4a5da8510fc6be843f8dea350ee46e2a26b2f54c"},
+    {file = "coverage-7.10.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2968647e3ed5a6c019a419264386b013979ff1fb67dd11f5c9886c43d6a31fc2"},
+    {file = "coverage-7.10.5-cp313-cp313-win32.whl", hash = "sha256:0d511dda38595b2b6934c2b730a1fd57a3635c6aa2a04cb74714cdfdd53846f4"},
+    {file = "coverage-7.10.5-cp313-cp313-win_amd64.whl", hash = "sha256:9a86281794a393513cf117177fd39c796b3f8e3759bb2764259a2abba5cce54b"},
+    {file = "coverage-7.10.5-cp313-cp313-win_arm64.whl", hash = "sha256:cebd8e906eb98bb09c10d1feed16096700b1198d482267f8bf0474e63a7b8d84"},
+    {file = "coverage-7.10.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0520dff502da5e09d0d20781df74d8189ab334a1e40d5bafe2efaa4158e2d9e7"},
+    {file = "coverage-7.10.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d9cd64aca68f503ed3f1f18c7c9174cbb797baba02ca8ab5112f9d1c0328cd4b"},
+    {file = "coverage-7.10.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0913dd1613a33b13c4f84aa6e3f4198c1a21ee28ccb4f674985c1f22109f0aae"},
+    {file = "coverage-7.10.5-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1b7181c0feeb06ed8a02da02792f42f829a7b29990fef52eff257fef0885d760"},
+    {file = "coverage-7.10.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:36d42b7396b605f774d4372dd9c49bed71cbabce4ae1ccd074d155709dd8f235"},
+    {file = "coverage-7.10.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b4fdc777e05c4940b297bf47bf7eedd56a39a61dc23ba798e4b830d585486ca5"},
+    {file = "coverage-7.10.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:42144e8e346de44a6f1dbd0a56575dd8ab8dfa7e9007da02ea5b1c30ab33a7db"},
+    {file = "coverage-7.10.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:66c644cbd7aed8fe266d5917e2c9f65458a51cfe5eeff9c05f15b335f697066e"},
+    {file = "coverage-7.10.5-cp313-cp313t-win32.whl", hash = "sha256:2d1b73023854068c44b0c554578a4e1ef1b050ed07cf8b431549e624a29a66ee"},
+    {file = "coverage-7.10.5-cp313-cp313t-win_amd64.whl", hash = "sha256:54a1532c8a642d8cc0bd5a9a51f5a9dcc440294fd06e9dda55e743c5ec1a8f14"},
+    {file = "coverage-7.10.5-cp313-cp313t-win_arm64.whl", hash = "sha256:74d5b63fe3f5f5d372253a4ef92492c11a4305f3550631beaa432fc9df16fcff"},
+    {file = "coverage-7.10.5-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:68c5e0bc5f44f68053369fa0d94459c84548a77660a5f2561c5e5f1e3bed7031"},
+    {file = "coverage-7.10.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:cf33134ffae93865e32e1e37df043bef15a5e857d8caebc0099d225c579b0fa3"},
+    {file = "coverage-7.10.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ad8fa9d5193bafcf668231294241302b5e683a0518bf1e33a9a0dfb142ec3031"},
+    {file = "coverage-7.10.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:146fa1531973d38ab4b689bc764592fe6c2f913e7e80a39e7eeafd11f0ef6db2"},
+    {file = "coverage-7.10.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6013a37b8a4854c478d3219ee8bc2392dea51602dd0803a12d6f6182a0061762"},
+    {file = "coverage-7.10.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:eb90fe20db9c3d930fa2ad7a308207ab5b86bf6a76f54ab6a40be4012d88fcae"},
+    {file = "coverage-7.10.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:384b34482272e960c438703cafe63316dfbea124ac62006a455c8410bf2a2262"},
+    {file = "coverage-7.10.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:467dc74bd0a1a7de2bedf8deaf6811f43602cb532bd34d81ffd6038d6d8abe99"},
+    {file = "coverage-7.10.5-cp314-cp314-win32.whl", hash = "sha256:556d23d4e6393ca898b2e63a5bca91e9ac2d5fb13299ec286cd69a09a7187fde"},
+    {file = "coverage-7.10.5-cp314-cp314-win_amd64.whl", hash = "sha256:f4446a9547681533c8fa3e3c6cf62121eeee616e6a92bd9201c6edd91beffe13"},
+    {file = "coverage-7.10.5-cp314-cp314-win_arm64.whl", hash = "sha256:5e78bd9cf65da4c303bf663de0d73bf69f81e878bf72a94e9af67137c69b9fe9"},
+    {file = "coverage-7.10.5-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:5661bf987d91ec756a47c7e5df4fbcb949f39e32f9334ccd3f43233bbb65e508"},
+    {file = "coverage-7.10.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a46473129244db42a720439a26984f8c6f834762fc4573616c1f37f13994b357"},
+    {file = "coverage-7.10.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1f64b8d3415d60f24b058b58d859e9512624bdfa57a2d1f8aff93c1ec45c429b"},
+    {file = "coverage-7.10.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:44d43de99a9d90b20e0163f9770542357f58860a26e24dc1d924643bd6aa7cb4"},
+    {file = "coverage-7.10.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a931a87e5ddb6b6404e65443b742cb1c14959622777f2a4efd81fba84f5d91ba"},
+    {file = "coverage-7.10.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f9559b906a100029274448f4c8b8b0a127daa4dade5661dfd821b8c188058842"},
+    {file = "coverage-7.10.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:b08801e25e3b4526ef9ced1aa29344131a8f5213c60c03c18fe4c6170ffa2874"},
+    {file = "coverage-7.10.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ed9749bb8eda35f8b636fb7632f1c62f735a236a5d4edadd8bbcc5ea0542e732"},
+    {file = "coverage-7.10.5-cp314-cp314t-win32.whl", hash = "sha256:609b60d123fc2cc63ccee6d17e4676699075db72d14ac3c107cc4976d516f2df"},
+    {file = "coverage-7.10.5-cp314-cp314t-win_amd64.whl", hash = "sha256:0666cf3d2c1626b5a3463fd5b05f5e21f99e6aec40a3192eee4d07a15970b07f"},
+    {file = "coverage-7.10.5-cp314-cp314t-win_arm64.whl", hash = "sha256:bc85eb2d35e760120540afddd3044a5bf69118a91a296a8b3940dfc4fdcfe1e2"},
+    {file = "coverage-7.10.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:62835c1b00c4a4ace24c1a88561a5a59b612fbb83a525d1c70ff5720c97c0610"},
+    {file = "coverage-7.10.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5255b3bbcc1d32a4069d6403820ac8e6dbcc1d68cb28a60a1ebf17e47028e898"},
+    {file = "coverage-7.10.5-cp39-cp39-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3876385722e335d6e991c430302c24251ef9c2a9701b2b390f5473199b1b8ebf"},
+    {file = "coverage-7.10.5-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8048ce4b149c93447a55d279078c8ae98b08a6951a3c4d2d7e87f4efc7bfe100"},
+    {file = "coverage-7.10.5-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4028e7558e268dd8bcf4d9484aad393cafa654c24b4885f6f9474bf53183a82a"},
+    {file = "coverage-7.10.5-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:03f47dc870eec0367fcdd603ca6a01517d2504e83dc18dbfafae37faec66129a"},
+    {file = "coverage-7.10.5-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:2d488d7d42b6ded7ea0704884f89dcabd2619505457de8fc9a6011c62106f6e5"},
+    {file = "coverage-7.10.5-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:b3dcf2ead47fa8be14224ee817dfc1df98043af568fe120a22f81c0eb3c34ad2"},
+    {file = "coverage-7.10.5-cp39-cp39-win32.whl", hash = "sha256:02650a11324b80057b8c9c29487020073d5e98a498f1857f37e3f9b6ea1b2426"},
+    {file = "coverage-7.10.5-cp39-cp39-win_amd64.whl", hash = "sha256:b45264dd450a10f9e03237b41a9a24e85cbb1e278e5a32adb1a303f58f0017f3"},
+    {file = "coverage-7.10.5-py3-none-any.whl", hash = "sha256:0be24d35e4db1d23d0db5c0f6a74a962e2ec83c426b5cac09f4234aadef38e4a"},
+    {file = "coverage-7.10.5.tar.gz", hash = "sha256:f2e57716a78bc3ae80b2207be0709a3b2b63b9f2dcf9740ee6ac03588a2015b6"},
+]
+
+[package.extras]
+toml = ["tomli"]
+
+[[package]]
 name = "curies"
 version = "0.7.10"
 description = "Idiomatic conversion between URIs and compact URIs (CURIEs)."
@@ -1510,25 +1610,31 @@ validators = ">=0.20.0,<0.21.0"
 
 [[package]]
 name = "koza"
-version = "0.7.2"
+version = "0.0.0"
 description = "Data transformation framework for LinkML data models"
 optional = false
-python-versions = "<4.0,>=3.9"
-files = [
-    {file = "koza-0.7.2-py3-none-any.whl", hash = "sha256:2fb1fd5c5457b4e725536f05c7bc342d026dbd2af4971c833dfd77e44ffd0e18"},
-    {file = "koza-0.7.2.tar.gz", hash = "sha256:1405e5a6ac97f9010167cfa45c9d832d67172fd317dc879c459ad2813392a1f9"},
-]
+python-versions = ">=3.10"
+files = []
+develop = false
 
 [package.dependencies]
+coverage = ">=7.6.10,<8.0.0"
 duckdb = "*"
-linkml = ">=1.7.8"
 loguru = "*"
+mergedeep = "1.3.4"
 ordered-set = ">=4.1.0"
 pydantic = ">=2.4,<3.0"
 pyyaml = ">=5.0.0"
 requests = ">=2.24.0,<3.0.0"
 sssom = ">=0.4"
+tqdm = ">=4.67.1,<5.0.0"
 typer = ">=0.12.3"
+
+[package.source]
+type = "git"
+url = "https://github.com/monarch-initiative/koza.git"
+reference = "main"
+resolved_reference = "1f6c67345adcbad49469c8d0d0653af2f6a8b07a"
 
 [[package]]
 name = "linkml"
@@ -4312,4 +4418,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "1da7e7834db250f03d1ccd46a82ec75c92f0e824315f9dbf32cc39e2e13c39ce"
+content-hash = "a904f17cfef7ceade64242e0126a753c3a6be10f951e1f5e7a18be6dcb7bf5cc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.10"
 importlib-metadata = ">=4.8.0"
-koza = ">=0.6.0"
+koza = {git = "https://github.com/monarch-initiative/koza.git", rev = "main"}
 kghub-downloader = "^0.4.1"
 kgx = ">=2.4.0"
 biolink-model = "^4.2.0"

--- a/src/zfin_orthology_ingest/cli.py
+++ b/src/zfin_orthology_ingest/cli.py
@@ -6,7 +6,8 @@ from pathlib import Path
 import typer
 from kghub_downloader.download_utils import download_from_yaml
 from kghub_downloader.model import DownloadOptions
-from koza.cli_utils import transform_source
+from koza.runner import KozaRunner
+from koza.model.formats import OutputFormat
 
 app = typer.Typer()
 logger = logging.getLogger(__name__)
@@ -36,19 +37,19 @@ def download(force: bool = typer.Option(False, help="Force download of data, eve
 @app.command()
 def transform(
     output_dir: str = typer.Option("output", help="Output directory for transformed data"),
-    row_limit: int = typer.Option(None, help="Number of rows to process"),
-    verbose: int = typer.Option(False, help="Whether to be verbose"),
+    row_limit: int = typer.Option(0, help="Number of rows to process"),
+    verbose: bool = typer.Option(False, help="Whether to be verbose"),
 ):
     """Run the Koza transform for zfin-orthology-ingest."""
     typer.echo("Transforming data for zfin-orthology-ingest...")
-    transform_code = Path(__file__).parent / "transform.yaml"
-    transform_source(
-        source=transform_code,
+    transform_config = Path(__file__).parent / "transform.yaml"
+    config, runner = KozaRunner.from_config_file(
+        str(transform_config),
         output_dir=output_dir,
-        output_format="tsv",
+        output_format=OutputFormat.tsv,
         row_limit=row_limit,
-        verbose=verbose,
     )
+    runner.run()
 
 
 if __name__ == "__main__":

--- a/src/zfin_orthology_ingest/transform.py
+++ b/src/zfin_orthology_ingest/transform.py
@@ -1,9 +1,7 @@
-import uuid  # For generating UUIDs for associations
+import uuid
 
+import koza
 from biolink_model.datamodel.pydanticmodel_v2 import AgentTypeEnum, GeneToGeneHomologyAssociation, KnowledgeLevelEnum
-from koza.cli_utils import get_koza_app
-
-koza_app = get_koza_app("zfin_orthology")
 
 # Mappings provided by Ceri Van Slyke from ZFIN, ORCID:0000-0002-2244-7917
 evidence_map = {
@@ -16,8 +14,8 @@ evidence_map = {
     "OT": "ECO:0000352", # Other to evidence used in manual assertion
 }
 
-while (row := koza_app.get_row()) is not None:
-
+@koza.transform_record()
+def transform_record(koza_transform, row):
     publications = [f"ZFIN:{pub}" for pub in row["publications"].split("|")] if row["publications"] else None
     evidence = evidence_map.get(row["evidence"], None)
     association = GeneToGeneHomologyAssociation(
@@ -32,4 +30,4 @@ while (row := koza_app.get_row()) is not None:
         knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
         agent_type=AgentTypeEnum.manual_agent,
     )
-    koza_app.write(association)
+    return [association]

--- a/src/zfin_orthology_ingest/transform.yaml
+++ b/src/zfin_orthology_ingest/transform.yaml
@@ -3,40 +3,30 @@
 
 name: "zfin_orthology"
 # metadata: "./src/zfin_orthology_ingest/metadata.yaml"
-format: "csv"
-delimiter: "\t"
-files:
-  - "./data/zfin_orthologs.tsv"
 
-columns:
-  - "zfin_gene"
-  - "ortholog_gene"
-  - "evidence"
-  - "publications"
+reader:
+  format: "csv"
+  delimiter: "\t"
+  files:
+    - "../../data/zfin_orthologs.tsv"
+  columns:
+    - "zfin_gene"
+    - "ortholog_gene"
+    - "evidence"
+    - "publications"
 
-edge_properties:
-  - id
-  - category
-  - subject
-  - predicate
-  - object
-  - has_evidence
-  - publications
-  - primary_knowledge_source
-  - aggregator_knowledge_source
-  - knowledge_level
-  - agent_type
-
-### Optional parameters - uncomment to use, or remove to ignore
-
-min_node_count: 0
-min_edge_count: 62186
-### CSV specific parameters
-
-# Delimiter for csv files (REQUIRED if format is csv)
-# columns: List of columns to include in output
-# header: Header row index
-# header_delimiter: Delimiter for header in csv files
-# header_prefix: Prefix for header in csv files
-# comment_char: Comment character for csv files
-# skip_blank_lines: Boolean - whether to skip blank lines in csv files
+writer:
+  edge_properties:
+    - id
+    - category
+    - subject
+    - predicate
+    - object
+    - has_evidence
+    - publications
+    - primary_knowledge_source
+    - aggregator_knowledge_source
+    - knowledge_level
+    - agent_type
+  min_node_count: 0
+  min_edge_count: 62186

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,42 +1,64 @@
 """
 An example test file for the transform script.
 
-It uses pytest fixtures to define the input data and the mock koza transform.
-The test_example function then tests the output of the transform script.
+It uses pytest fixtures to define the input data and the KozaRunner.
+The test functions then test the output of the transform script.
 
 See the Koza documentation for more information on testing transforms:
 https://koza.monarchinitiative.org/Usage/testing/
 """
 
 import pytest
-from koza.utils.testing_utils import mock_koza
+from biolink_model.datamodel.pydanticmodel_v2 import GeneToGeneHomologyAssociation
+from koza.io.writer.writer import KozaWriter
+from koza.runner import KozaRunner, KozaTransformHooks
+from zfin_orthology_ingest.transform import transform_record
 
-# Define the ingest name and transform script path
-INGEST_NAME = "zfin_orthology"
-TRANSFORM_SCRIPT = "./src/zfin_orthology_ingest/transform.py"
+class MockWriter(KozaWriter):
+    def __init__(self):
+        self.items = []
+
+    def write(self, entities):
+        self.items += entities
+
+    def finalize(self):
+        pass
+
 
 
 @pytest.fixture
-def single_pub_entities(mock_koza):
+def single_pub_entities():
+    writer = MockWriter()
     row = {
         "zfin_gene": "ZFIN:ZDB-GENE-080513-4",
         "ortholog_gene": "HGNC:973",
         "evidence": "AA",
         "publications": "ZDB-PUB-030905-1",
     }
-
-    return mock_koza(INGEST_NAME, row, TRANSFORM_SCRIPT)
+    runner = KozaRunner(
+        data=iter([row]),
+        writer=writer,
+        hooks=KozaTransformHooks(transform_record=[transform_record])
+    )
+    runner.run()
+    return writer.items
 
 @pytest.fixture
-def multi_pub_entities(mock_koza):
+def multi_pub_entities():
+    writer = MockWriter()
     row = {
         "zfin_gene": "ZFIN:ZDB-GENE-110510-1",
         "ortholog_gene": "HGNC:11795",
         "evidence": "AA",
         "publications": "ZDB-PUB-030905-1|ZDB-PUB-140530-4|ZDB-PUB-181103-13",
     }
-
-    return mock_koza(INGEST_NAME, row, TRANSFORM_SCRIPT)
+    runner = KozaRunner(
+        data=iter([row]),
+        writer=writer,
+        hooks=KozaTransformHooks(transform_record=[transform_record])
+    )
+    runner.run()
+    return writer.items
 
 
 


### PR DESCRIPTION
## Summary
- Updates zfin-orthology-ingest to work with the latest koza API
- Migrates from the old while-loop pattern to the new decorator-based approach
- Fixes file path resolution issues with the new koza version

## Changes Made

### Transform Function (`transform.py`)
- ✅ Added `@koza.transform_record()` decorator
- ✅ Updated imports: added `import koza`, removed deprecated `koza.cli_utils`
- ✅ Changed from `while (row := koza_app.get_row())` pattern to decorated function
- ✅ Updated function to return `[association]` instead of calling `koza_app.write()`

### Configuration (`transform.yaml`)
- ✅ Updated to new nested structure with `reader` and `writer` sections
- ✅ Fixed file path resolution: `./data/zfin_orthologs.tsv` → `../../data/zfin_orthologs.tsv`
- ✅ Moved edge properties under `writer` section

### Tests (`test_transform.py`)
- ✅ Replaced `mock_koza` with `KozaRunner` and `KozaTransformHooks`
- ✅ Added `MockWriter` class extending `KozaWriter`
- ✅ Updated imports to use new koza testing API
- ✅ All tests passing with new patterns

## Test Results
```
============================= test session starts ==============================
tests/test_transform.py::test_single_pub_entities PASSED                 [ 50%]
tests/test_transform.py::test_multi_pub_entities PASSED                  [100%]
============================== 2 passed in 2.29s
```

## Transform Verification
Tested transform with CLI - successfully processes data and generates output:
```
poetry run python -c "from zfin_orthology_ingest.cli import app; import typer; app()" transform --row-limit 5 --verbose
```

## Breaking Changes
This update requires the latest version of koza and follows the new API patterns introduced in:
- [PR #163: API Refactoring](https://github.com/monarch-initiative/koza/pull/163)
- [PR #169: Decorator-based API](https://github.com/monarch-initiative/koza/pull/169)

🤖 Generated with [Claude Code](https://claude.ai/code)